### PR TITLE
enable to build the sample device on Darwin/macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.a
 *.so
+*.dylib
 *.elf
 *.elf.*

--- a/device/sample/build/build.bash
+++ b/device/sample/build/build.bash
@@ -11,13 +11,17 @@ fi
 
 if [ $1 = "all" ]
 then
-	if [ $TARGET_OS = "Linux" ]
+	if [ $TARGET_OS = "Linux" ] || [ $TARGET_OS = "Darwin" ]
 	then
 		cmake .. -DProtobuf_DIR=/usr/local/grpc/lib/cmake/protobuf  -Wno-dev
 	else
 		cmake .. -DOPENSSL_ROOT_DIR=${OPENSSL_PATH}
 	fi
 	make
+	if [ $TARGET_OS = "Darwin" ]
+	then
+		cp libdevsample.dylib libdevsample.so
+	fi
 elif [ $1 = "clean" ]
 then
 	echo "clean up"

--- a/device/sample/build/build.bash
+++ b/device/sample/build/build.bash
@@ -18,13 +18,18 @@ then
 		cmake .. -DOPENSSL_ROOT_DIR=${OPENSSL_PATH}
 	fi
 	make
+elif [ $1 = "clean" ]
+then
+	echo "clean up"
+	rm -r ./CMakeFiles
+	rm Makefile
+	#rm sample_client*
+	#rm sample.*
+	rm CMake*
+	rm cmake*
+	rm libdev*
+	rm -r ./grpc
 else
-	rm -rf ./CMakeFiles
-	rm -f Makefile
-	rm -f sample_client*
-	rm -f sample.*
-	rm -f CMake*
-	rm -f cmake*
-	rm -f libdev*
-	rm -rf ./grpc
+	echo "$0 {all|clean}"
+	exit 1
 fi


### PR DESCRIPTION
`athrill-device/device/sample/build` をmacOSネイティブでビルドできるようにしました．
grpcのインストールは必要です．Dockerfileを参考にしました．
https://github.com/toppers/athrill-device/blob/057b51ed257483293c2aa93196e4bc8980115bf9/docker/v850/Dockerfile.athrill#L32-L39

macだとライブラリの拡張子が .dylib になるので，athrillが美味しく食べられるように無理くり .so にrename (cp)しています．

誰得？ですが俺得です．どうでしょうか〜？？