### PR TITLE
Reduce docker image to be built.

### DIFF
--- a/docker/v850/Dockerfile.athrill
+++ b/docker/v850/Dockerfile.athrill
@@ -45,17 +45,18 @@ RUN mkdir -p /root/grpc-build && \
 ENV PATH /usr/local/grpc/bin:${PATH}
 
 # Install grpc for Ruby
-RUN	gem install grpc
-RUN	gem install grpc-tools
+RUN	gem install grpc grpc-tools
 
 # Install athrill development environment
 RUN mkdir /root/workspace
 WORKDIR /root/workspace
-RUN wget https://github.com/toppers/athrill-gcc-v850e2m/releases/download/v1.1/athrill-gcc-package.tar.gz 
-RUN tar xzvf athrill-gcc-package.tar.gz && \
+RUN wget https://github.com/toppers/athrill-gcc-v850e2m/releases/download/v1.1/athrill-gcc-package.tar.gz && \
+    tar xzf athrill-gcc-package.tar.gz && \
 	cd athrill-gcc-package && \
-	tar xzvf athrill-gcc.tar.gz
-RUN rm -f athrill-gcc-package.tar.gz
+	tar xzf athrill-gcc.tar.gz && \
+    rm -f athrill-gcc.tar.gz && \
+	cd ../ && \
+    rm -f athrill-gcc-package.tar.gz
 ENV PATH /root/workspace/athrill-gcc-package/usr/local/athrill-gcc/bin/:${PATH}
 ENV PATH /root/workspace/athrill/bin/linux:${PATH}
 


### PR DESCRIPTION
Dockerイメージファイルの削減を行ってみました。

- gemインストールをまとめてコミットするようにしています
- athrill-gccのアーカイブファイルを削除するパス情報が間違っていたようで修正しました
- athrill-gccの展開はverbosオプションを外して処理を早くしました

1.78GBから1.37GBになっていることを確認しています。